### PR TITLE
optimize: reduce Netlify production deploys to save credits

### DIFF
--- a/.github/workflows/landing-page-ci-cd.yml
+++ b/.github/workflows/landing-page-ci-cd.yml
@@ -1,17 +1,34 @@
 name: Landing Page CI/CD
 
 on:
+  # Tagged releases trigger production deploy (15 credits)
   push:
-    branches: [master, develop]
+    tags:
+      - 'v*'           # Matches v1.0.0, v1.2.3, etc.
+      - 'release-*'    # Matches release-2026-01-24, etc.
     paths:
       - 'experimental/landing-pages/**'
       - '.github/workflows/landing-page-ci-cd.yml'
       - '.htmlvalidate.json'
+
+  # Pull requests get preview deploys (FREE - no credits consumed)
   pull_request:
     branches: [master]
     paths:
       - 'experimental/landing-pages/**'
       - '.htmlvalidate.json'
+
+  # Manual trigger from GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      deploy_type:
+        description: 'Deployment type'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - preview
 
 env:
   NODE_VERSION: '20'
@@ -61,12 +78,14 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
 
-  # Lighthouse performance audit (runs after deployment)
+  # Lighthouse performance audit (runs after production deployment only)
   lighthouse-audit:
     name: Lighthouse Performance Audit
     runs-on: ubuntu-latest
     needs: deploy-netlify
-    if: github.ref == 'refs/heads/master'
+    if: |
+      startsWith(github.ref, 'refs/tags/') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'production')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,14 +103,20 @@ jobs:
           uploadArtifacts: false
           temporaryPublicStorage: false
 
-  # Deploy to Netlify (Preview for PRs, Production for main)
+  # Deploy to Netlify
+  # - PRs: Preview deploy (FREE)
+  # - Tags: Production deploy (15 credits)
+  # - Manual: Based on input (15 credits for production)
   deploy-netlify:
     name: Deploy to Netlify
     runs-on: ubuntu-latest
     needs: quality-check
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/tags/')
     environment:
-      name: ${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }}
+      name: ${{ (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'production')) && 'production' || 'preview' }}
       url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout code
@@ -124,12 +149,14 @@ jobs:
               body: `✅ Landing page deployed to preview:\n\n🔗 ${{ steps.deploy.outputs.url }}\n\nPlease review before merging.`
             });
 
-  # Post-deployment tests
+  # Post-deployment tests (runs after production deployment only)
   post-deployment-tests:
     name: Post-Deployment Tests
     runs-on: ubuntu-latest
     needs: deploy-netlify
-    if: github.ref == 'refs/heads/master'
+    if: |
+      startsWith(github.ref, 'refs/tags/') ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'production')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,10 @@
   # No build command needed for static HTML
   command = "echo 'Static site - no build required'"
 
+  # Ignore automatic Netlify builds - we deploy only via GitHub Actions
+  # This prevents Netlify from consuming build minutes on every commit
+  ignore = "exit 0"
+
 # Production context (master branch)
 [context.production]
   publish = "experimental/landing-pages"


### PR DESCRIPTION
This change implements a two-layer optimization strategy to reduce
unnecessary Netlify production deployments from ~600 to ~120-180
credits per month (70-75% savings).

Changes:
1. netlify.toml: Add build ignore rule to prevent Netlify's automatic
   builds on every commit (forces GitHub Actions-only deploys)

2. Workflow triggers: Production deploys now only occur on:
   - Tagged releases (v*, release-*)
   - Manual workflow dispatch from GitHub UI
   - PR preview deploys remain FREE (no credit consumption)

3. Workflow conditions: Updated deploy-netlify, lighthouse-audit, and
   post-deployment-tests jobs to run only for production deployments

Impact:
- Before: Every commit to master = 15 credits
- After: Only intentional releases = 15 credits
- PR previews: Always FREE (unchanged)
- Estimated savings: ~420-480 credits/month

Deployment workflow:
- Feature work: Create PR → get free preview deploy → merge
- Production release: Tag commit (git tag v1.0.0) → auto-deploy
- Emergency deploy: Use workflow_dispatch button in GitHub UI

This enforces proper PR workflow while dramatically reducing costs.