### PR TITLE
fix: add permissions for security scan upload and update CodeQL to v4

### DIFF
--- a/.github/workflows/landing-page-ci-cd.yml
+++ b/.github/workflows/landing-page-ci-cd.yml
@@ -40,6 +40,10 @@ jobs:
   quality-check:
     name: Quality & Security Checks
     runs-on: ubuntu-latest
+    permissions:
+      actions: read          # Required for workflow telemetry
+      contents: read         # Required to checkout code
+      security-events: write # Required to upload security scan results
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,7 +74,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload security scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Fix: Security scan permissions and CodeQL version

### Problem
The GitHub Action was failing with "Resource not accessible by integration" error when trying to upload security scan results.

### Solution
- Added explicit permissions to `quality-check` job:
  - `actions: read` - Required for workflow telemetry
  - `security-events: write` - Required to upload SARIF results
- Updated `github/codeql-action` from v3 to v4 (v3 deprecated in 2026)

### Changes
- Added permissions block to quality-check job
- Updated CodeQL action version

### Files Changed
- `.github/workflows/landing-page-ci-cd.yml`