### PR TITLE
fix: enable production deployment for tag releases

### DIFF
--- a/.github/workflows/landing-page-ci-cd.yml
+++ b/.github/workflows/landing-page-ci-cd.yml
@@ -129,6 +129,7 @@ jobs:
         with:
           publish-dir: './experimental/landing-pages'
           production-branch: master
+          production-deploy: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'production') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions - ${{ github.event.head_commit.message }}"
           enable-pull-request-comment: true


### PR DESCRIPTION
## Fix: Enable production deployment for tag releases

### Problem
Tag-based releases (v1.01) were not deploying to production on Netlify - they were creating preview deployments instead.

### Solution
Added `production-deploy` parameter to the Netlify action, set to true when:
- Push is a tag (starts with `refs/tags/`)
- Manual workflow dispatch with production type

### Files Changed
- `.github/workflows/landing-page-ci-cd.yml` - Added production-deploy parameter
