### PR TITLE
feat(F005): HTML email templates for Kit welcome sequence

### DIFF
--- a/docs/email-templates/01-confirmation-welcome.md
+++ b/docs/email-templates/01-confirmation-welcome.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Combined double opt-in confirmation + welcome + story preview
 **Timing:** Automatic (sent by Buttondown on signup)
-**Buttondown Setup:** Settings → Emails → Confirmation email
+**Kit Setup:** Settings → Email → Confirmation email
 
 ---
 
@@ -73,14 +73,15 @@ The Storytime Team
 
 ---
 
-## Buttondown Configuration Notes
+## Kit Configuration Notes
 
-1. Navigate to **Settings → Emails → Confirmation email**
-2. Enable **"Custom confirmation email"**
-3. Paste the content above
-4. **CRITICAL:** Ensure `{{ confirmation_url }}` is inside the confirm button/link
-5. Send a test email to verify formatting
-6. Test the confirmation link works
+1. Navigate to **Settings → Email → Confirmation email**
+2. Click **Edit** or **Customize**
+3. Switch to **HTML mode**
+4. Use `html/01-confirmation-welcome.html` for styled version
+5. **CRITICAL:** Ensure `{{ confirmation_url }}` is inside the confirm button/link
+6. Send a test email to verify formatting
+7. Test the confirmation link works
 
 ## Target Metrics
 

--- a/docs/email-templates/02-vision.md
+++ b/docs/email-templates/02-vision.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Share the product story, build emotional connection
 **Timing:** Day 2 (48 hours after confirmation)
-**Send Method:** Manual via Buttondown dashboard
+**Send Method:** Automated via Kit sequence (Day 2)
 
 ---
 
@@ -78,13 +78,13 @@ P.S. - Still curious about your child's current favorite story! Hit reply if you
 
 ---
 
-## Sending Instructions
+## Kit Setup Instructions
 
-1. Go to Buttondown → **Emails** → **New email**
-2. Copy the subject line and content above
-3. Set "Send to" = Subscribers who confirmed 2 days ago
-4. Preview and send
-5. Log in tracking spreadsheet
+1. Go to Kit → **Sequences** → Your welcome sequence
+2. Add email with **2-day delay** after confirmation
+3. Use `html/02-vision.html` for styled version
+4. Preview and save
+5. Sequence handles sending automatically
 
 ## Target Metrics
 

--- a/docs/email-templates/03-sneak-peek.md
+++ b/docs/email-templates/03-sneak-peek.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Preview features, generate excitement
 **Timing:** Day 5 (after confirmation)
-**Send Method:** Manual via Buttondown dashboard
+**Send Method:** Automated via Kit sequence (Day 5)
 
 ---
 
@@ -76,13 +76,13 @@ The Storytime Team
 
 ---
 
-## Sending Instructions
+## Kit Setup Instructions
 
-1. Go to Buttondown → **Emails** → **New email**
-2. Copy the subject line and content above
-3. Set "Send to" = Subscribers who confirmed 5 days ago
-4. Preview and send
-5. Log in tracking spreadsheet
+1. Go to Kit → **Sequences** → Your welcome sequence
+2. Add email with **5-day delay** after confirmation
+3. Use `html/03-sneak-peek.html` for styled version
+4. Preview and save
+5. Sequence handles sending automatically
 
 ## Target Metrics
 

--- a/docs/email-templates/04-engagement.md
+++ b/docs/email-templates/04-engagement.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Request feedback, deepen relationship, identify engaged subscribers
 **Timing:** Day 10 (after confirmation)
-**Send Method:** Manual via Buttondown dashboard
+**Send Method:** Automated via Kit sequence (Day 10)
 
 ---
 
@@ -81,14 +81,14 @@ P.S. - Everyone who replies gets added to our "VIP early access" list. You'll ge
 
 ---
 
-## Sending Instructions
+## Kit Setup Instructions
 
-1. Go to Buttondown → **Emails** → **New email**
-2. Copy the subject line and content above
-3. Set "Send to" = Subscribers who confirmed 10 days ago
-4. Preview and send
-5. Log in tracking spreadsheet
-6. **Important:** Track replies for VIP list
+1. Go to Kit → **Sequences** → Your welcome sequence
+2. Add email with **10-day delay** after confirmation
+3. Use `html/04-engagement.html` for styled version
+4. Preview and save
+5. Sequence handles sending automatically
+6. **Important:** Monitor replies for VIP list
 
 ## Target Metrics
 

--- a/docs/email-templates/README.md
+++ b/docs/email-templates/README.md
@@ -3,80 +3,67 @@
 This directory contains email templates for the Storytime welcome sequence.
 
 **PRD Reference:** `docs/prds/F005-email-welcome-sequence.md`
-**GitHub Issue:** #29
+**GitHub Issue:** #18 (with sub-issues #29, #30)
+**Email Platform:** Kit (formerly ConvertKit)
 
 ---
+
+## Directory Structure
+
+```
+email-templates/
+├── README.md                    # This file
+├── 01-confirmation-welcome.md   # Markdown content - confirmation email
+├── 02-vision.md                 # Markdown content - Day 2
+├── 03-sneak-peek.md             # Markdown content - Day 5
+├── 04-engagement.md             # Markdown content - Day 10
+└── html/
+    ├── README.md                # Kit setup instructions
+    ├── _base-template.html      # Base HTML template
+    ├── 01-confirmation-welcome.html
+    ├── 02-vision.html
+    ├── 03-sneak-peek.html
+    └── 04-engagement.html
+```
 
 ## Quick Start
 
-### Step 1: Configure Confirmation/Welcome Email (Automatic)
+### For Kit Setup (HTML Templates)
 
-This email is sent automatically by Buttondown when someone signs up.
+See `html/README.md` for detailed Kit configuration instructions.
 
-1. Log into [Buttondown](https://buttondown.email/)
-2. Go to **Settings** → **Emails** → **Confirmation email**
-3. Enable **"Custom confirmation email"**
-4. Copy content from `01-confirmation-welcome.md`
-5. **CRITICAL:** Ensure `{{ confirmation_url }}` is in the confirm button
-6. Save and send a test email
+**Quick steps:**
+1. Go to Kit Dashboard → Settings → Email → Confirmation email
+2. Paste `html/01-confirmation-welcome.html` (ensure `{{ confirmation_url }}` is present)
+3. Create a new Sequence with emails #2, #3, #4
+4. Connect sequence to your signup form
 
-### Step 2: Create Follow-up Email Templates (Manual Sending)
+### Template Overview
 
-These emails are sent manually based on days since confirmation.
-
-| Email | File | When to Send |
-|-------|------|--------------|
-| Vision | `02-vision.md` | Day 2 after confirmation |
-| Sneak Peek | `03-sneak-peek.md` | Day 5 after confirmation |
-| Engagement | `04-engagement.md` | Day 10 after confirmation |
-
-To save as drafts in Buttondown:
-1. Go to **Emails** → **New email**
-2. Copy subject and content from template file
-3. Save as draft (don't send yet)
-4. Repeat for all 3 templates
+| Email | File | Timing | Subject Line |
+|-------|------|--------|--------------|
+| Confirmation/Welcome | `01-*` | Immediate | Confirm your spot in the Storytime universe |
+| Vision | `02-*` | Day 2 | Why I'm building Storytime |
+| Sneak Peek | `03-*` | Day 5 | How Storytime remembers (sneak peek inside) |
+| Engagement | `04-*` | Day 10 | Quick question (I'd love your input) |
 
 ---
 
-## Daily Manual Process (Phase A)
+## File Types
 
-**Time required:** 5-10 minutes/day
+### Markdown Files (*.md)
+- **Purpose:** Human-readable content for review and editing
+- **Use:** Edit these to update email copy
+- **Format:** Plain text with formatting hints
 
-1. **Check Buttondown dashboard** for newly confirmed subscribers
-2. **Identify which email to send** based on confirmation date:
-   - Day 0-1: They just got the confirmation email
-   - Day 2: Send Vision email
-   - Day 5: Send Sneak Peek email
-   - Day 10: Send Engagement email
-3. **Send the appropriate email** via Buttondown
-4. **Log in tracking spreadsheet** (see template below)
-
----
-
-## Tracking Spreadsheet Template
-
-Create a Google Sheet with these columns:
-
-| Subscriber Email | Confirmed Date | Email 1 (Welcome) | Email 2 (Vision) | Email 3 (Sneak Peek) | Email 4 (Engagement) | Notes |
-|------------------|----------------|-------------------|------------------|----------------------|----------------------|-------|
-| user@example.com | 2026-01-25 | ✅ Auto | ⏳ 01-27 | ⏳ 01-30 | ⏳ 02-04 | |
-
-**Legend:**
-- ✅ = Sent (with date)
-- ⏳ = Scheduled (with target date)
-- ❌ = Unsubscribed
-- 📩 = Replied (add to VIP list)
-
----
-
-## Template Files
-
-| File | Purpose |
-|------|---------|
-| `01-confirmation-welcome.md` | Automatic confirmation + welcome + story excerpt |
-| `02-vision.md` | Day 2 - Founder story, build emotional connection |
-| `03-sneak-peek.md` | Day 5 - Feature preview, generate excitement |
-| `04-engagement.md` | Day 10 - Request feedback, identify engaged users |
+### HTML Files (html/*.html)
+- **Purpose:** Production-ready templates for Kit
+- **Use:** Copy/paste directly into Kit's HTML editor
+- **Features:**
+  - Matches Storytime landing page design
+  - Mobile responsive
+  - Email client compatible (Outlook, Gmail, Apple Mail)
+  - Kit template variables included
 
 ---
 
@@ -84,35 +71,44 @@ Create a Google Sheet with these columns:
 
 | Metric | Target | Where to Find |
 |--------|--------|---------------|
-| Confirmation email open rate | >60% | Buttondown analytics |
-| Confirmation rate (clicks) | >50% | Buttondown analytics |
-| Follow-up avg open rate | >40% | Buttondown analytics |
-| Unsubscribe rate | <2% | Buttondown analytics |
+| Confirmation email open rate | >60% | Kit analytics |
+| Confirmation rate (clicks) | >50% | Kit analytics |
+| Follow-up avg open rate | >40% | Kit analytics |
+| Unsubscribe rate | <2% | Kit analytics |
 | Reply rate | >5% | Count manually |
 
 ---
 
-## Buttondown Configuration Checklist
+## Kit Configuration Checklist
 
-- [ ] Custom confirmation email enabled
-- [ ] Confirmation email content added with `{{ confirmation_url }}`
+- [ ] Custom confirmation email configured with HTML template
+- [ ] `{{ confirmation_url }}` verified in confirmation button
 - [ ] Reply-to set to monitored inbox
-- [ ] Test confirmation flow works end-to-end
-- [ ] Email #2, #3, #4 saved as drafts
-- [ ] Tracking spreadsheet created
+- [ ] Welcome sequence created with 3 emails (Day 2, 5, 10)
+- [ ] Sequence connected to signup form
+- [ ] Test emails sent and verified in multiple clients
+- [ ] Mobile rendering tested
 
 ---
 
-## Phase B: Automation (Future)
+## Updating Email Content
 
-When any of these trigger points are reached:
-- 100 signups achieved
-- Manual process taking >30 min/day
-- Missing sends due to human error
+### Workflow
 
-**Then:** Upgrade to Buttondown Standard ($29/mo) for automations.
+1. **Edit Markdown** - Update content in `*.md` files
+2. **Update HTML** - Apply changes to `html/*.html` files
+3. **Test locally** - Open HTML in browser to preview
+4. **Update Kit** - Paste new HTML into Kit dashboard
+5. **Send test** - Verify rendering in email clients
 
-See PRD Section 11 for automation setup instructions.
+### Design Elements
+
+The HTML templates include these branded elements:
+- **Gradient background:** Midnight → Twilight → Deep Purple
+- **Card layout:** Subtle glass-morphism effect
+- **Gold accents:** Buttons, highlights, borders
+- **Story excerpts:** Styled quote blocks
+- **Feature lists:** Emoji + text formatting
 
 ---
 
@@ -121,7 +117,7 @@ See PRD Section 11 for automation setup instructions.
 **Confirmation email not being received:**
 - Check spam folder
 - Verify subscriber email is correct
-- Check Buttondown logs for bounces
+- Check Kit logs for bounces
 
 **Links not working in emails:**
 - Ensure `{{ confirmation_url }}` is correctly formatted
@@ -132,6 +128,21 @@ See PRD Section 11 for automation setup instructions.
 - Verify emails aren't landing in spam
 - Test different send times
 
+**Broken layout:**
+- Use the HTML templates (not Markdown)
+- Test in multiple email clients
+- Check Kit's preview feature
+
 ---
 
-**Last Updated:** 2026-01-25
+## Phase B: Automation
+
+Currently using Kit's built-in automation:
+- Confirmation email: Automatic on signup
+- Follow-up sequence: Automatic delays (Day 2, 5, 10)
+
+All automation is handled by Kit - no manual intervention required once configured.
+
+---
+
+**Last Updated:** 2026-01-28

--- a/docs/email-templates/html/01-confirmation-welcome.html
+++ b/docs/email-templates/html/01-confirmation-welcome.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>Confirm your spot in the Storytime universe</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+        a {
+            color: #fbbf24;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+            .button-td {
+                display: block !important;
+                width: 100% !important;
+            }
+            .button {
+                display: block !important;
+                width: 100% !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Preview text -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        Click to confirm + get a sneak peek of the magic inside...
+        &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
+    </div>
+
+    <!-- Email wrapper -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            <!-- Greeting -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Hi there,
+                            </p>
+
+                            <!-- Welcome heading -->
+                            <h2 style="font-family: Georgia, 'Times New Roman', serif; font-size: 28px; font-weight: 700; color: #fef3c7; margin: 0 0 16px 0;">
+                                Welcome to the Storytime universe!
+                            </h2>
+
+                            <!-- Introduction -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 32px 0;">
+                                You're one click away from joining a community of parents who believe bedtime stories should be more than random tales&mdash;they should be adventures that remember, characters that return, and worlds that grow with your child.
+                            </p>
+
+                            <!-- CTA Button -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td align="center" style="padding-bottom: 16px;">
+                                        <!--[if mso]>
+                                        <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ confirmation_url }}" style="height:48px;v-text-anchor:middle;width:240px;" arcsize="25%" strokecolor="#f59e0b" fillcolor="#fbbf24">
+                                            <w:anchorlock/>
+                                            <center style="color:#0f1419;font-family:sans-serif;font-size:16px;font-weight:bold;">Confirm Your Spot</center>
+                                        </v:roundrect>
+                                        <![endif]-->
+                                        <!--[if !mso]><!-->
+                                        <a href="{{ confirmation_url }}" class="button" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%); color: #0f1419; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; border-radius: 12px; text-align: center;">
+                                            Confirm Your Spot
+                                        </a>
+                                        <!--<![endif]-->
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center">
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0;">
+                                            &#9757; Click to confirm your subscription
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Divider -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 32px 0;">
+                                        <div style="border-top: 1px solid rgba(251, 191, 36, 0.3);"></div>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Story excerpt intro -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                <strong style="color: #fef3c7;">While you're here, here's a tiny taste of what Storytime creates:</strong>
+                            </p>
+
+                            <!-- Story excerpt box -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="background: rgba(255, 255, 255, 0.03); border-left: 4px solid #fbbf24; padding: 20px 24px; border-radius: 0 12px 12px 0;">
+                                        <p style="font-family: Georgia, 'Times New Roman', serif; font-size: 16px; line-height: 1.8; color: #f9fafb; font-style: italic; margin: 0 0 16px 0;">
+                                            "Maya pushed open the garden gate and gasped. The flowers glowed softly in the twilight, and a gentle 'whoo' came from the old oak tree. A beautiful silver owl swooped down, landing on a low branch.
+                                        </p>
+                                        <p style="font-family: Georgia, 'Times New Roman', serif; font-size: 16px; line-height: 1.8; color: #f9fafb; font-style: italic; margin: 0;">
+                                            'Hello Maya,' said the owl in a voice like wind chimes. 'I'm Whisper, guardian of the Whispering Garden. We've been waiting for someone brave enough to hear the flowers' secrets.'"
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                That's Maya meeting Whisper the Owl for the first time. In Storytime, Whisper will remember Maya&mdash;and your child&mdash;night after night.
+                            </p>
+
+                            <!-- What's next -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 32px 0 16px 0;">
+                                What's Next
+                            </h3>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Once you confirm, you'll hear from me a few times over the next couple weeks with:
+                            </p>
+
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 8px;">The story behind why I'm building this</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 8px;">A deeper look at how the "story memory" works</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 8px;">A chance to shape what we build</span>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0 32px 0;">
+                                No spam. Just genuine updates from a parent building something for parents.
+                            </p>
+
+                            <!-- Closing -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 8px 0;">
+                                Click the button above to confirm, and let the adventure begin.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0 0 0;">
+                                Warmly,<br>
+                                <strong style="color: #fef3c7;">The Storytime Team</strong>
+                            </p>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                <em>(If you didn't sign up for Storytime, you can safely ignore this email.)</em>
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/docs/email-templates/html/01-confirmation-welcome.html
+++ b/docs/email-templates/html/01-confirmation-welcome.html
@@ -71,10 +71,10 @@
         &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
     </div>
 
-    <!-- Email wrapper -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+    <!-- Email wrapper - solid color for email client compatibility -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #1a1f3a;">
         <tr>
-            <td align="center" style="padding: 40px 16px;">
+            <td align="center" style="padding: 40px 16px; background-color: #1a1f3a;">
 
                 <!-- Main container -->
                 <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
@@ -221,9 +221,14 @@
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
                                 <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
                                 &nbsp;|&nbsp;
-                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Preferences</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Website</a>
                             </p>
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                {{ address }}
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 8px 0 0 0;">
                                 <em>(If you didn't sign up for Storytime, you can safely ignore this email.)</em>
                             </p>
                         </td>

--- a/docs/email-templates/html/02-vision.html
+++ b/docs/email-templates/html/02-vision.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>Why I'm building Storytime</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+        a {
+            color: #fbbf24;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Preview text -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        It started with a simple request at bedtime...
+        &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
+    </div>
+
+    <!-- Email wrapper -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            <!-- Greeting -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Hi there,
+                            </p>
+
+                            <!-- The story -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Last year, my daughter asked me something that stopped me in my tracks.
+                            </p>
+
+                            <!-- Quote highlight -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="background: rgba(251, 191, 36, 0.1); border-left: 4px solid #fbbf24; padding: 16px 20px; border-radius: 0 12px 12px 0; margin: 16px 0;">
+                                        <p style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; line-height: 1.6; color: #fef3c7; font-style: italic; margin: 0;">
+                                            "Dad, can we have the same story, but different?"
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                She wanted to see her favorite character again&mdash;but in a NEW adventure. She wanted continuity. She wanted a universe that remembered.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                I looked for an app that could do this. Generate personalized stories? Sure, plenty of those. But stories that REMEMBER? Characters that RETURN? A universe that GROWS?
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #f9fafb; margin: 0 0 32px 0;">
+                                <strong>Nothing.</strong>
+                            </p>
+
+                            <!-- The Problem section -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 0 0 16px 0;">
+                                The Problem
+                            </h3>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Every AI story app I found had the same issue: <strong style="color: #f9fafb;">amnesia</strong>. Each story started fresh. No memory. No callbacks. No "remember when we saved the forest sprites?" No inside jokes. No beloved companions returning.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 32px 0;">
+                                It felt... hollow.
+                            </p>
+
+                            <!-- The Vision section -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 0 0 16px 0;">
+                                The Vision
+                            </h3>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Storytime is different. We're building:
+                            </p>
+
+                            <!-- Feature list -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 10px 0;">
+                                        <span style="font-size: 18px;">&#10024;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Persistent characters</strong> who remember your child</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 10px 0;">
+                                        <span style="font-size: 18px;">&#127769;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Story arcs</strong> that span weeks and months</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 10px 0;">
+                                        <span style="font-size: 18px;">&#129417;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">House characters</strong> (like Whisper the Owl) who become true companions</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 10px 0;">
+                                        <span style="font-size: 18px;">&#128218;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">A universe</strong> that grows richer with every bedtime</span>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                Your child won't just hear stories. They'll <strong style="color: #fef3c7;">LIVE in a story universe</strong> that's uniquely theirs.
+                            </p>
+
+                            <!-- Divider -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 24px 0;">
+                                        <div style="border-top: 1px solid rgba(251, 191, 36, 0.3);"></div>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Closing -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                That's what I'm building. And I'd love for your family to be part of it.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Next time, I'll show you exactly how the "story memory" works. It's pretty magical.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 8px 0;">
+                                Talk soon,<br>
+                                <strong style="color: #fef3c7;">The Storytime Team</strong>
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; line-height: 1.7; color: #9ca3af; font-style: italic; margin: 24px 0 0 0;">
+                                P.S. - Still curious about your child's current favorite story! Hit reply if you have a moment.
+                            </p>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/docs/email-templates/html/02-vision.html
+++ b/docs/email-templates/html/02-vision.html
@@ -63,10 +63,10 @@
         &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
     </div>
 
-    <!-- Email wrapper -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+    <!-- Email wrapper - solid color for email client compatibility -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #1a1f3a;">
         <tr>
-            <td align="center" style="padding: 40px 16px;">
+            <td align="center" style="padding: 40px 16px; background-color: #1a1f3a;">
 
                 <!-- Main container -->
                 <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
@@ -210,7 +210,12 @@
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
                                 <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
                                 &nbsp;|&nbsp;
-                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Preferences</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Website</a>
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                {{ address }}
                             </p>
                         </td>
                     </tr>

--- a/docs/email-templates/html/03-sneak-peek.html
+++ b/docs/email-templates/html/03-sneak-peek.html
@@ -66,10 +66,10 @@
         &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
     </div>
 
-    <!-- Email wrapper -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+    <!-- Email wrapper - solid color for email client compatibility -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #1a1f3a;">
         <tr>
-            <td align="center" style="padding: 40px 16px;">
+            <td align="center" style="padding: 40px 16px; background-color: #1a1f3a;">
 
                 <!-- Main container -->
                 <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
@@ -218,7 +218,12 @@
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
                                 <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
                                 &nbsp;|&nbsp;
-                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Preferences</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Website</a>
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                {{ address }}
                             </p>
                         </td>
                     </tr>

--- a/docs/email-templates/html/03-sneak-peek.html
+++ b/docs/email-templates/html/03-sneak-peek.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>How Storytime remembers (sneak peek inside)</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+        a {
+            color: #fbbf24;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+            .story-box {
+                padding: 16px !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Preview text -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        Here's how story continuity actually works...
+        &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
+    </div>
+
+    <!-- Email wrapper -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            <!-- Greeting -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Hi there,
+                            </p>
+
+                            <!-- The hook -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Remember Maya and Whisper the Owl from my first email? Let me show you how their story <strong style="color: #fef3c7;">EVOLVED</strong> over a week of bedtimes.
+                            </p>
+
+                            <!-- Story progression boxes -->
+                            <!-- Night 1 -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 16px;">
+                                <tr>
+                                    <td class="story-box" style="background: rgba(251, 191, 36, 0.05); border: 1px solid rgba(251, 191, 36, 0.2); border-radius: 12px; padding: 20px;">
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; font-weight: 600; color: #fbbf24; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 8px 0;">
+                                            Night 1
+                                        </p>
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #d1d5db; margin: 0;">
+                                            Maya meets Whisper in the Whispering Garden. Whisper teaches her to understand the language of flowers.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Night 3 -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 16px;">
+                                <tr>
+                                    <td class="story-box" style="background: rgba(251, 191, 36, 0.05); border: 1px solid rgba(251, 191, 36, 0.2); border-radius: 12px; padding: 20px;">
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; font-weight: 600; color: #fbbf24; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 8px 0;">
+                                            Night 3
+                                        </p>
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #d1d5db; margin: 0;">
+                                            The garden sprites need help! Maya uses her new flower-language skills <em style="color: #fbbf24;">(callback!)</em> to solve the mystery. Whisper is proud.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Night 7 -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 24px;">
+                                <tr>
+                                    <td class="story-box" style="background: rgba(251, 191, 36, 0.05); border: 1px solid rgba(251, 191, 36, 0.2); border-radius: 12px; padding: 20px;">
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; font-weight: 600; color: #fbbf24; text-transform: uppercase; letter-spacing: 0.1em; margin: 0 0 8px 0;">
+                                            Night 7
+                                        </p>
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #d1d5db; margin: 0;">
+                                            A new child, Luna, discovers the garden. Maya&mdash;now confident&mdash;becomes the teacher, showing Luna what Whisper taught her.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Insight -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 32px 0;">
+                                See what happened? Maya <strong style="color: #fef3c7;">GREW</strong>. She went from student to teacher. The story remembered her journey.
+                            </p>
+
+                            <!-- The Features section -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 0 0 16px 0;">
+                                Here's what powers this:
+                            </h3>
+
+                            <!-- Feature list -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 12px 0;">
+                                        <span style="font-size: 18px;">&#129504;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Story Memory</strong> &mdash; Each story builds on the last</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 12px 0;">
+                                        <span style="font-size: 18px;">&#128100;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Character Persistence</strong> &mdash; Whisper remembers everything</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 12px 0;">
+                                        <span style="font-size: 18px;">&#127917;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Character Growth</strong> &mdash; Your child's character evolves</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 12px 0;">
+                                        <span style="font-size: 18px;">&#127757;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;"><strong style="color: #fef3c7;">Universe Building</strong> &mdash; New locations unlock over time</span>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                And yes, it all happens automatically. You just say "another adventure" and the magic continues.
+                            </p>
+
+                            <!-- Divider -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 24px 0;">
+                                        <div style="border-top: 1px solid rgba(251, 191, 36, 0.3);"></div>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Excitement builder -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                We're putting the finishing touches on the first version now. Early waitlist members (that's you!) will be first to try it.
+                            </p>
+
+                            <!-- Closing -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                One more email coming in a few days. I have a question for you that will actually shape what we build.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0;">
+                                Until then,<br>
+                                <strong style="color: #fef3c7;">The Storytime Team</strong>
+                            </p>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/docs/email-templates/html/04-engagement.html
+++ b/docs/email-templates/html/04-engagement.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>Quick question (I'd love your input)</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+        a {
+            color: #fbbf24;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Preview text -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        Your answer will directly shape what we build...
+        &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
+    </div>
+
+    <!-- Email wrapper -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            <!-- Greeting -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Hi there,
+                            </p>
+
+                            <!-- The ask -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                I have a question for you&mdash;and your answer will directly influence what we build first.
+                            </p>
+
+                            <!-- The question highlight -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-bottom: 24px;">
+                                <tr>
+                                    <td style="background: rgba(251, 191, 36, 0.1); border: 2px solid rgba(251, 191, 36, 0.3); border-radius: 12px; padding: 24px; text-align: center;">
+                                        <p style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; line-height: 1.5; color: #fef3c7; font-weight: 700; margin: 0;">
+                                            What's the #1 thing that would make bedtime stories better for your family?
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Just hit reply and tell me. Could be:
+                            </p>
+
+                            <!-- Example responses -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 6px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; color: #9ca3af; margin-left: 8px; font-style: italic;">"My kid gets bored of the same themes"</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 6px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; color: #9ca3af; margin-left: 8px; font-style: italic;">"I want stories that teach kindness without being preachy"</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 6px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; color: #9ca3af; margin-left: 8px; font-style: italic;">"We need shorter stories for busy nights"</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 6px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; color: #9ca3af; margin-left: 8px; font-style: italic;">"I wish we could save favorite stories"</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 6px 0;">
+                                        <span style="color: #fbbf24;">&#8226;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; color: #d1d5db; margin-left: 8px;">Something completely different!</span>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                No wrong answers. <strong style="color: #fef3c7;">I read every reply personally.</strong>
+                            </p>
+
+                            <!-- Why this matters -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 32px 0 16px 0;">
+                                Why This Matters
+                            </h3>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                We're a small team building something new. Unlike big companies that build what they THINK parents want, we can actually build what you TELL US you want.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 18px; line-height: 1.7; color: #fef3c7; font-weight: 600; margin: 0 0 32px 0;">
+                                Your reply = real influence.
+                            </p>
+
+                            <!-- Status update -->
+                            <h3 style="font-family: Georgia, 'Times New Roman', serif; font-size: 20px; font-weight: 700; color: #fef3c7; margin: 0 0 16px 0;">
+                                Quick update on where we are:
+                            </h3>
+
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #22c55e;">&#10003;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;">Story generation engine working</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #22c55e;">&#10003;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;">Character persistence working</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #fbbf24;">&#8634;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;">Building the parent dashboard</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding: 8px 0;">
+                                        <span style="color: #6b7280;">&#9203;</span>
+                                        <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: #d1d5db; margin-left: 12px;">Launch coming soon</span>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 24px 0;">
+                                You'll be among the first to know when it's ready.
+                            </p>
+
+                            <!-- Divider -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                                <tr>
+                                    <td style="padding: 24px 0;">
+                                        <div style="border-top: 1px solid rgba(251, 191, 36, 0.3);"></div>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <!-- Closing -->
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 16px 0;">
+                                Thanks for being on this journey with us. Seriously&mdash;it means a lot.
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 24px 0;">
+                                Now, hit reply and tell me: <strong style="color: #fef3c7;">what would make bedtime stories better?</strong>
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; line-height: 1.7; color: #d1d5db; margin: 0 0 8px 0;">
+                                <strong style="color: #fef3c7;">The Storytime Team</strong>
+                            </p>
+
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; line-height: 1.7; color: #9ca3af; font-style: italic; margin: 24px 0 0 0;">
+                                P.S. - Everyone who replies gets added to our "VIP early access" list. You'll get to try Storytime before the general waitlist.
+                            </p>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/docs/email-templates/html/04-engagement.html
+++ b/docs/email-templates/html/04-engagement.html
@@ -64,7 +64,7 @@
     </div>
 
     <!-- Email wrapper -->
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #1a1f3a;">
         <tr>
             <td align="center" style="padding: 40px 16px;">
 
@@ -234,7 +234,12 @@
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
                                 <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
                                 &nbsp;|&nbsp;
-                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Preferences</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Website</a>
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                {{ address }}
                             </p>
                         </td>
                     </tr>

--- a/docs/email-templates/html/README.md
+++ b/docs/email-templates/html/README.md
@@ -39,12 +39,35 @@ These templates use the Storytime brand design system:
 
 These templates use Kit's Liquid templating syntax:
 
-| Variable | Description |
-|----------|-------------|
-| `{{ confirmation_url }}` | Double opt-in confirmation link (Email #1 only) |
-| `{{ unsubscribe_url }}` | Unsubscribe link |
-| `{{ address }}` | Physical mailing address (CAN-SPAM compliance) |
-| `{{ subscriber.first_name }}` | Subscriber's first name (if collected) |
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `{{ confirmation_url }}` | Double opt-in confirmation link | Yes (Email #1 only) |
+| `{{ unsubscribe_url }}` | Unsubscribe link | Yes (all emails) |
+| `{{ subscriber_preferences_url }}` | Subscriber preferences link | Yes (all emails) |
+| `{{ address }}` | Physical mailing address | Yes (CAN-SPAM) |
+| `{{ message_content }}` | Content from visual editor | Yes (wrapper template only) |
+| `{{ subscriber.first_name }}` | Subscriber's first name | Optional |
+
+**Important:** Kit requires `{{ unsubscribe_url }}`, `{{ subscriber_preferences_url }}`, and `{{ address }}` in all email templates for compliance.
+
+## Email Client Compatibility
+
+These templates are designed for maximum email client compatibility:
+
+- **No JavaScript** - Email clients block JS execution
+- **Table-based layout** - Required for Outlook compatibility
+- **Solid background colors** - CSS gradients don't render in all clients
+- **Inline styles** - More reliable than `<style>` blocks in some clients
+- **System fonts** - Web fonts may not load in email
+- **MSO conditionals** - Outlook-specific fixes included
+
+## Template Types
+
+### Standalone Emails (01-04)
+Complete HTML emails for use in Kit's "Custom HTML" mode. Copy entire file contents into Kit.
+
+### Wrapper Template (kit-wrapper-template.html)
+A wrapper template for Kit's visual editor. Uses `{{ message_content }}` to inject content you write in Kit's editor. Use this if you prefer Kit's visual editor over raw HTML.
 
 ## Loading Templates into Kit
 

--- a/docs/email-templates/html/README.md
+++ b/docs/email-templates/html/README.md
@@ -1,0 +1,145 @@
+# HTML Email Templates for Kit
+
+These HTML email templates are designed to match the Storytime landing page styling and are ready to be loaded into Kit (formerly ConvertKit).
+
+## Template Files
+
+| File | Subject Line | Timing | Purpose |
+|------|--------------|--------|---------|
+| `01-confirmation-welcome.html` | Confirm your spot in the Storytime universe | Automatic on signup | Double opt-in + welcome + story preview |
+| `02-vision.html` | Why I'm building Storytime | Day 2 | Founder story, emotional connection |
+| `03-sneak-peek.html` | How Storytime remembers (sneak peek inside) | Day 5 | Feature preview, generate excitement |
+| `04-engagement.html` | Quick question (I'd love your input) | Day 10 | Request feedback, identify engaged users |
+
+## Design System
+
+These templates use the Storytime brand design system:
+
+### Colors
+- **Midnight:** `#0f1419` - Background
+- **Twilight:** `#1a1f3a` - Secondary background
+- **Deep Purple:** `#2d1b4e` - Accent background
+- **Purple:** `#6366f1` - Border accent
+- **Amber:** `#f59e0b` - Primary CTA
+- **Gold:** `#fbbf24` - Highlights, links
+- **Cream:** `#fef3c7` - Headings
+- **Text Primary:** `#f9fafb` - Emphasis text
+- **Text Secondary:** `#d1d5db` - Body text
+
+### Typography
+- **Headings:** Georgia, serif (fallback for Fraunces)
+- **Body:** System font stack (-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif)
+
+### Layout
+- Max width: 600px
+- Mobile responsive with media queries
+- Table-based layout for email client compatibility
+
+## Kit Template Variables
+
+These templates use Kit's Liquid templating syntax:
+
+| Variable | Description |
+|----------|-------------|
+| `{{ confirmation_url }}` | Double opt-in confirmation link (Email #1 only) |
+| `{{ unsubscribe_url }}` | Unsubscribe link |
+| `{{ address }}` | Physical mailing address (CAN-SPAM compliance) |
+| `{{ subscriber.first_name }}` | Subscriber's first name (if collected) |
+
+## Loading Templates into Kit
+
+### Step 1: Confirmation Email (Email #1)
+
+1. Go to Kit Dashboard → **Settings** → **Email**
+2. Find **Confirmation email** section
+3. Click **Edit** or **Customize**
+4. Switch to HTML mode
+5. Copy the entire contents of `01-confirmation-welcome.html`
+6. Paste into the HTML editor
+7. **Verify** the `{{ confirmation_url }}` variable is in the button link
+8. Save and send a test email
+
+### Step 2: Create Email Sequence
+
+1. Go to Kit Dashboard → **Sequences**
+2. Click **+ New Sequence**
+3. Name it "Storytime Welcome Sequence"
+
+#### Add Email #2 (Vision)
+1. Click **+ Add Email**
+2. Set delay: **2 days** after subscription
+3. Subject: `Why I'm building Storytime`
+4. Switch to HTML mode
+5. Paste contents of `02-vision.html`
+6. Save
+
+#### Add Email #3 (Sneak Peek)
+1. Click **+ Add Email**
+2. Set delay: **5 days** after subscription
+3. Subject: `How Storytime remembers (sneak peek inside)`
+4. Switch to HTML mode
+5. Paste contents of `03-sneak-peek.html`
+6. Save
+
+#### Add Email #4 (Engagement)
+1. Click **+ Add Email**
+2. Set delay: **10 days** after subscription
+3. Subject: `Quick question (I'd love your input)`
+4. Switch to HTML mode
+5. Paste contents of `04-engagement.html`
+6. Save
+
+### Step 3: Connect Sequence to Form
+
+1. Go to Kit Dashboard → **Forms & Landing Pages**
+2. Select your signup form
+3. Under **Incentive** or **Settings**, find sequence settings
+4. Connect the "Storytime Welcome Sequence"
+
+## Testing
+
+Before going live:
+
+1. **Send test emails** to yourself from Kit
+2. **Check rendering** in:
+   - Gmail (web + mobile)
+   - Apple Mail (iOS + Mac)
+   - Outlook (web)
+3. **Verify links** work correctly
+4. **Test on mobile** devices
+5. **Check spam score** using Kit's built-in tools
+
+## Customization
+
+### Updating Content
+1. Edit the HTML files in this directory
+2. Re-paste into Kit
+3. Content is between the `<td class="content">` tags
+
+### Using the Base Template
+`_base-template.html` provides the foundational structure. To create new emails:
+1. Copy the base template
+2. Replace `{{EMAIL_TITLE}}` with your subject
+3. Replace `{{PREVIEW_TEXT}}` with preview text
+4. Replace `{{EMAIL_CONTENT}}` with your content
+
+## Troubleshooting
+
+**Emails landing in spam:**
+- Ensure `{{ unsubscribe_url }}` is present
+- Keep image-to-text ratio low
+- Avoid spammy words in subject lines
+
+**Broken layout in Outlook:**
+- Use table-based layout (already implemented)
+- Avoid CSS properties unsupported by Outlook
+- Test with Litmus or Email on Acid
+
+**Images not loading:**
+- Host images on reliable CDN
+- Always include alt text
+- Use absolute URLs
+
+---
+
+**Last Updated:** 2026-01-28

--- a/docs/email-templates/html/_base-template.html
+++ b/docs/email-templates/html/_base-template.html
@@ -185,10 +185,12 @@
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
                                 <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
                                 &nbsp;|&nbsp;
-                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Preferences</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Website</a>
                             </p>
                             <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
-                                Storytime &bull; {{ address }}
+                                {{ address }}
                             </p>
                         </td>
                     </tr>

--- a/docs/email-templates/html/_base-template.html
+++ b/docs/email-templates/html/_base-template.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>{{EMAIL_TITLE}}</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        /* Reset styles */
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        /* Base styles */
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+
+        /* Typography */
+        .body-text {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            font-size: 16px;
+            line-height: 1.7;
+            color: #d1d5db;
+        }
+
+        .heading {
+            font-family: Georgia, 'Times New Roman', serif;
+            font-weight: 700;
+            color: #fef3c7;
+        }
+
+        .heading-gradient {
+            background: linear-gradient(135deg, #fef3c7 0%, #fbbf24 50%, #f59e0b 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        /* Links */
+        a {
+            color: #fbbf24;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Button */
+        .button {
+            display: inline-block;
+            padding: 14px 28px;
+            background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%);
+            color: #0f1419 !important;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            font-size: 16px;
+            font-weight: 600;
+            text-decoration: none;
+            border-radius: 12px;
+            text-align: center;
+        }
+
+        /* Card styles */
+        .card {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(251, 191, 36, 0.2);
+            border-radius: 16px;
+            padding: 24px;
+        }
+
+        /* Story excerpt */
+        .story-excerpt {
+            background: rgba(255, 255, 255, 0.03);
+            border-left: 4px solid #fbbf24;
+            padding: 20px 24px;
+            margin: 24px 0;
+            font-style: italic;
+            color: #f9fafb;
+        }
+
+        /* Emoji/Icon highlight */
+        .highlight {
+            color: #fbbf24;
+        }
+
+        /* Footer */
+        .footer {
+            font-size: 14px;
+            color: #9ca3af;
+            text-align: center;
+        }
+
+        .footer a {
+            color: #9ca3af;
+        }
+
+        /* Mobile responsiveness */
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+            .heading {
+                font-size: 28px !important;
+            }
+            .button {
+                display: block !important;
+                width: 100% !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Preview text -->
+    <div style="display: none; max-height: 0; overflow: hidden;">
+        {{PREVIEW_TEXT}}
+        &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847; &#847;
+    </div>
+
+    <!-- Email wrapper -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background: linear-gradient(180deg, #0f1419 0%, #1a1f3a 40%, #2d1b4e 100%);">
+        <tr>
+            <td align="center" style="padding: 40px 16px;">
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            {{EMAIL_CONTENT}}
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td class="footer" style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #6b7280; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a>
+                                &nbsp;|&nbsp;
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </p>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                Storytime &bull; {{ address }}
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/docs/email-templates/html/kit-wrapper-template.html
+++ b/docs/email-templates/html/kit-wrapper-template.html
@@ -1,0 +1,245 @@
+<!--
+  Storytime Email Template for Kit
+
+  This is a WRAPPER TEMPLATE for Kit's visual email editor.
+  Use this in: Kit Dashboard → Settings → Email templates → Create new template
+
+  The {{ message_content }} variable will be replaced with content you write
+  in Kit's visual editor when composing emails.
+
+  For COMPLETE standalone emails (confirmation, sequences), see the
+  numbered HTML files which should be used in "Custom HTML" mode.
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+    <title>Storytime</title>
+
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+
+    <style>
+        /* Reset */
+        body, table, td, p, a, li, blockquote {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            max-width: 100%;
+        }
+
+        /* Base */
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+            background-color: #0f1419;
+        }
+
+        /* Message content styling */
+        .message-content {
+            max-width: 600px;
+            margin: 0 auto;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        }
+
+        .message-content div {
+            padding-bottom: 10px;
+        }
+
+        .message-content img {
+            max-width: 100%;
+            height: auto;
+            margin: 0 auto;
+        }
+
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: Georgia, 'Times New Roman', serif;
+            color: #fef3c7;
+            margin: 0 0 16px 0;
+        }
+
+        h1 { font-size: 32px; }
+        h2 { font-size: 24px; }
+        h3 { font-size: 18px; }
+
+        p, li, ul, ol, div {
+            font-size: 16px;
+            line-height: 1.7;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            color: #d1d5db;
+        }
+
+        p *, li * {
+            color: inherit;
+            font-family: inherit;
+            font-size: inherit;
+        }
+
+        p, ul, ol {
+            margin-bottom: 1em;
+        }
+
+        /* Blockquote - Story excerpt style */
+        blockquote {
+            border-left: 4px solid #fbbf24;
+            margin: 20px 0;
+            padding: 20px 24px;
+            font-size: 16px;
+            line-height: 1.8;
+            color: #f9fafb;
+            font-style: italic;
+            font-family: Georgia, 'Times New Roman', serif;
+            background: rgba(255, 255, 255, 0.03);
+            border-radius: 0 12px 12px 0;
+        }
+
+        /* Links */
+        a {
+            text-decoration: none;
+            color: #fbbf24;
+        }
+
+        a:hover {
+            color: #f59e0b;
+            text-decoration: underline;
+        }
+
+        /* Buttons */
+        .button {
+            border: none;
+            background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%);
+            color: #0f1419 !important;
+            padding: 14px 28px;
+            display: inline-block;
+            margin: 10px 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            font-weight: 600;
+            font-size: 16px;
+            border-radius: 12px;
+            text-decoration: none;
+        }
+
+        .button:hover {
+            color: #0f1419 !important;
+            background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
+        }
+
+        /* Footer */
+        .footer {
+            border-top: 1px solid rgba(251, 191, 36, 0.3);
+            padding: 24px 0;
+            margin-top: 32px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            color: #6b7280;
+            font-size: 12px;
+            text-align: center;
+        }
+
+        .footer a {
+            color: #6b7280;
+        }
+
+        .footer a:hover {
+            color: #9ca3af;
+        }
+
+        /* Mobile */
+        @media only screen and (max-width: 600px) {
+            .container {
+                width: 100% !important;
+                padding: 16px !important;
+            }
+            .content {
+                padding: 24px 16px !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f1419;">
+    <!-- Email wrapper - solid fallback for clients that don't support gradients -->
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #0f1419;">
+        <tr>
+            <td align="center" style="padding: 40px 16px; background-color: #1a1f3a;">
+
+                <!--[if mso]>
+                <center>
+                <table><tr><td width="600">
+                <![endif]-->
+
+                <!-- Main container -->
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="container" style="max-width: 600px; width: 100%;">
+
+                    <!-- Header with logo -->
+                    <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                            <h1 style="font-family: Georgia, 'Times New Roman', serif; font-size: 32px; font-weight: 700; margin: 0; color: #fef3c7;">
+                                Storytime
+                            </h1>
+                        </td>
+                    </tr>
+
+                    <!-- Email content card -->
+                    <tr>
+                        <td class="content" style="background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(99, 102, 241, 0.2); border-radius: 24px; padding: 40px 32px;">
+
+                            <!-- Kit message content variable - REQUIRED -->
+                            <div class="message-content">
+                                {{ message_content }}
+                            </div>
+
+                        </td>
+                    </tr>
+
+                    <!-- Footer - REQUIRED for compliance -->
+                    <tr>
+                        <td style="padding: 32px 16px; text-align: center;">
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; color: #9ca3af; margin: 0 0 16px 0;">
+                                Made with love by parents, for parents
+                            </p>
+                            <div class="footer" style="border-top: none; padding: 0; margin: 0;">
+                                <a href="{{ unsubscribe_url }}" style="color: #6b7280;">Unsubscribe</a> |
+                                <a href="{{ subscriber_preferences_url }}" style="color: #6b7280;">Update your profile</a> |
+                                <a href="https://getstorytime.vercel.app" style="color: #6b7280;">Visit website</a>
+                            </div>
+                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; color: #4b5563; margin: 16px 0 0 0;">
+                                {{ address }}
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+
+                <!--[if mso]>
+                </td></tr></table>
+                </center>
+                <![endif]-->
+
+            </td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add production-ready HTML email templates for the F005 welcome sequence
- Templates match Storytime landing page design (colors, typography, layout)
- All templates include Kit required variables for compliance
- Email client compatible (Outlook, Gmail, Apple Mail)

## Changes

### New HTML Email Templates (`docs/email-templates/html/`)

| Template | Purpose | Timing |
|----------|---------|--------|
| `01-confirmation-welcome.html` | Double opt-in + welcome + story preview | Automatic |
| `02-vision.html` | Founder story, emotional connection | Day 2 |
| `03-sneak-peek.html` | Feature preview, show story memory | Day 5 |
| `04-engagement.html` | Feedback request, VIP identification | Day 10 |
| `kit-wrapper-template.html` | Wrapper for Kit's visual editor | N/A |
| `_base-template.html` | Base template structure | N/A |

### Kit Compliance
All templates include required variables:
- `{{ unsubscribe_url }}`
- `{{ subscriber_preferences_url }}`
- `{{ address }}`
- `{{ confirmation_url }}` (Email #1 only)

### Email Client Compatibility
- Solid background colors (no CSS gradients for Outlook)
- Table-based layout
- No JavaScript
- Inline styles
- System fonts with fallbacks
- MSO conditionals for Outlook

### Documentation
- Updated markdown files to reference Kit instead of Buttondown
- Added Kit setup instructions and configuration checklist

## Test plan

- [ ] Open HTML templates in browser to verify rendering
- [ ] Copy templates into Kit and send test emails
- [ ] Verify rendering in Gmail, Apple Mail, and Outlook
- [ ] Confirm all Kit variables render correctly
- [ ] Test unsubscribe and preferences links work
- [ ] Verify mobile responsiveness

## Related issues

Closes #29, Closes #30
Related to #18
